### PR TITLE
Support for unified Integer class in Ruby 2.4+

### DIFF
--- a/lib/vagrant-hosts-provisioner/config.rb
+++ b/lib/vagrant-hosts-provisioner/config.rb
@@ -57,7 +57,7 @@ module VagrantPlugins
 
       # Checks if a option is a Number
       def validate_number(key, value)
-        if !value.kind_of?(Fixnum) && !value.kind_of?(NilClass)
+        if !value.kind_of?(Integer) && !value.kind_of?(NilClass)
           I18n.t('vagrant_hostsprovisioner.error.not_a_number', {
             :config_key    => key,
             :invalid_class => value.class.to_s


### PR DESCRIPTION
In 2016 the release of Ruby 2.4 unified Fixnum and Bignum into Integer: https://bugs.ruby-lang.org/issues/12005

Time to move on and avoid warning messages like
```
/home/nschlemm/.vagrant.d/gems/2.4.3/gems/vagrant-hosts-provisioner-2.0/lib/vagr
ant-hosts-provisioner/config.rb:60: warning: constant ::Fixnum is deprecated
```